### PR TITLE
Creados códigos para descargar y visualizar (de forma somera) los datos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+code/ErroresDescarga.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 code/ErroresDescarga.txt
+.ipynb_checkpoints

--- a/code/DownloadCMIP6.py
+++ b/code/DownloadCMIP6.py
@@ -1,14 +1,22 @@
 from pyesgf.search import SearchConnection
 import xarray as xr
+import numpy as np
 import os.path as op
 from tqdm import tqdm
 from datetime import datetime
 
-conn = SearchConnection('http://esgf-data.dkrz.de/esg-search',
+Alemania = "https://esgf-data.dkrz.de/esg-search/"
+Francia = "https://esgf-node.ipsl.upmc.fr/esg-search/"
+
+conn = SearchConnection(Francia,
                         distrib=True)
 
+# We need to download variables:
+# prc: Convective precipitation
+# pr: Non-convective precipitation
+VAR_NAME = 'pr'
 ctx = conn.new_context(project='CMIP6',
-                       variable='prc',
+                       variable=VAR_NAME,
                        experiment_id="historical",
                        frequency="day")
 datos = ctx.search()
@@ -20,17 +28,22 @@ for idx, i in tqdm(enumerate(datos), total=len(datos)):
     fc = fc[0]
     if fc.opendap_url is None:
         continue
-    outfile = op.join("./CMIP6", op.basename(fc.opendap_url))
+    outfile = op.join("/srv/SystematicClimate/CMIP6", op.basename(fc.opendap_url))
     if op.isfile(outfile):
         continue
     try:
         with xr.open_dataset(fc.opendap_url) as ds:
-            prc = ds["prc"]
-            prc = prc.sel(lat=slice(43, 44), lon=slice(355, 357))
+            prc = ds[VAR_NAME]
+            prc = prc.sel(lat = slice(34, 46),
+                          lon = prc.lon[(prc.lon<5) | (prc.lon>350)])
+            prc = prc.assign_coords(lon = (((prc.lon + 180) % 360) - 180))
+            prc = prc.roll(lon = (-np.nonzero(prc.lon.values < 0)[0][0]), roll_coords=True)
             prc.to_netcdf(outfile)
-    except:
+    except Exception as e:
         print("Ha habido un problema con el fichero: ", op.basename(fc.opendap_url))
+        print(e)
         print("Seguimos a por el próximo")
         with open("./ErroresDescarga.txt", "at") as fid:
             fid.write(op.basename(fc.opendap_url))
             fid.write("\n")
+        

--- a/code/DownloadCMIP6.py
+++ b/code/DownloadCMIP6.py
@@ -1,0 +1,36 @@
+from pyesgf.search import SearchConnection
+import xarray as xr
+import os.path as op
+from tqdm import tqdm
+from datetime import datetime
+
+conn = SearchConnection('http://esgf-data.dkrz.de/esg-search',
+                        distrib=True)
+
+ctx = conn.new_context(project='CMIP6',
+                       variable='prc',
+                       experiment_id="historical",
+                       frequency="day")
+datos = ctx.search()
+
+for idx, i in tqdm(enumerate(datos), total=len(datos)):
+    fc = i.file_context().search()
+    if len(fc)==0:
+        continue
+    fc = fc[0]
+    if fc.opendap_url is None:
+        continue
+    outfile = op.join("./CMIP6", op.basename(fc.opendap_url))
+    if op.isfile(outfile):
+        continue
+    try:
+        with xr.open_dataset(fc.opendap_url) as ds:
+            prc = ds["prc"]
+            prc = prc.sel(lat=slice(43, 44), lon=slice(355, 357))
+            prc.to_netcdf(outfile)
+    except:
+        print("Ha habido un problema con el fichero: ", op.basename(fc.opendap_url))
+        print("Seguimos a por el próximo")
+        with open("./ErroresDescarga.txt", "at") as fid:
+            fid.write(op.basename(fc.opendap_url))
+            fid.write("\n")

--- a/notebooks/CheckDownloads.ipynb
+++ b/notebooks/CheckDownloads.ipynb
@@ -1,0 +1,446 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "43ae2c22-8806-4cd4-ae52-9317fc8cece6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from glob import glob\n",
+    "import os.path as op\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2888b14d-b535-479e-9510-61febb28b12b",
+   "metadata": {},
+   "source": [
+    "Vamos a cargar todos los dato que hemos descargado en un DataFrame para poder inspeccionar rápidamente qué modelos tenemos descargados."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1dce0436-e06b-4c30-9a15-01593f24ce90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ficheros = glob(\"/srv/SystematicClimate/CMIP6/*.nc\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cae1f627-038f-4e86-8c4c-7c57d4a90f1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(index=list(range(len(ficheros))), columns=[\"Var\", \"TRes\", \"Model\", \"Scenario\", \"Ensemble\", \"NPI\", \"Dates\", \"File\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6acee381-5cf9-4c19-8aae-ae12546ef575",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for idx, i in enumerate(ficheros):\n",
+    "    df.loc[idx] = [*op.basename(i).split(\".\")[0].split(\"_\"), i]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8b22acaf-5626-4dcf-a6fe-d87e92bfd2e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[\"InitDate\"] = df[\"Dates\"].apply(lambda x: int(x.split(\"-\")[0][:4]))\n",
+    "df[\"EndDate\"] = df[\"Dates\"].apply(lambda x: int(x.split(\"-\")[1][:4]))\n",
+    "df[\"TCoverage\"] = df[\"EndDate\"] - df[\"InitDate\"]\n",
+    "df = df[df[\"EndDate\"]>=2014]\n",
+    "df = df.drop(\"Dates\", axis=1)\n",
+    "df = df.reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "7f15594d-0dd0-4351-8340-5d5c6d763db8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>index</th>\n",
+       "      <th>Var</th>\n",
+       "      <th>TRes</th>\n",
+       "      <th>Model</th>\n",
+       "      <th>Scenario</th>\n",
+       "      <th>Ensemble</th>\n",
+       "      <th>NPI</th>\n",
+       "      <th>File</th>\n",
+       "      <th>InitDate</th>\n",
+       "      <th>EndDate</th>\n",
+       "      <th>TCoverage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>pr</td>\n",
+       "      <td>day</td>\n",
+       "      <td>IPSL-CM6A-LR</td>\n",
+       "      <td>historical</td>\n",
+       "      <td>r11i1p1f1</td>\n",
+       "      <td>gr</td>\n",
+       "      <td>/srv/SystematicClimate/CMIP6/pr_day_IPSL-CM6A-...</td>\n",
+       "      <td>1850</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>164</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>6</td>\n",
+       "      <td>pr</td>\n",
+       "      <td>day</td>\n",
+       "      <td>CAMS-CSM1-0</td>\n",
+       "      <td>historical</td>\n",
+       "      <td>r2i1p1f1</td>\n",
+       "      <td>gn</td>\n",
+       "      <td>/srv/SystematicClimate/CMIP6/pr_day_CAMS-CSM1-...</td>\n",
+       "      <td>1850</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>164</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>7</td>\n",
+       "      <td>pr</td>\n",
+       "      <td>day</td>\n",
+       "      <td>CanESM5</td>\n",
+       "      <td>historical</td>\n",
+       "      <td>r19i1p2f1</td>\n",
+       "      <td>gn</td>\n",
+       "      <td>/srv/SystematicClimate/CMIP6/pr_day_CanESM5_hi...</td>\n",
+       "      <td>1850</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>164</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>10</td>\n",
+       "      <td>pr</td>\n",
+       "      <td>day</td>\n",
+       "      <td>IPSL-CM6A-LR</td>\n",
+       "      <td>historical</td>\n",
+       "      <td>r12i1p1f1</td>\n",
+       "      <td>gr</td>\n",
+       "      <td>/srv/SystematicClimate/CMIP6/pr_day_IPSL-CM6A-...</td>\n",
+       "      <td>1850</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>164</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>11</td>\n",
+       "      <td>pr</td>\n",
+       "      <td>day</td>\n",
+       "      <td>IPSL-CM6A-LR</td>\n",
+       "      <td>historical</td>\n",
+       "      <td>r3i1p1f1</td>\n",
+       "      <td>gr</td>\n",
+       "      <td>/srv/SystematicClimate/CMIP6/pr_day_IPSL-CM6A-...</td>\n",
+       "      <td>1850</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>164</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   index Var TRes         Model    Scenario   Ensemble NPI  \\\n",
+       "0      1  pr  day  IPSL-CM6A-LR  historical  r11i1p1f1  gr   \n",
+       "1      6  pr  day   CAMS-CSM1-0  historical   r2i1p1f1  gn   \n",
+       "2      7  pr  day       CanESM5  historical  r19i1p2f1  gn   \n",
+       "3     10  pr  day  IPSL-CM6A-LR  historical  r12i1p1f1  gr   \n",
+       "4     11  pr  day  IPSL-CM6A-LR  historical   r3i1p1f1  gr   \n",
+       "\n",
+       "                                                File  InitDate  EndDate  \\\n",
+       "0  /srv/SystematicClimate/CMIP6/pr_day_IPSL-CM6A-...      1850     2014   \n",
+       "1  /srv/SystematicClimate/CMIP6/pr_day_CAMS-CSM1-...      1850     2014   \n",
+       "2  /srv/SystematicClimate/CMIP6/pr_day_CanESM5_hi...      1850     2014   \n",
+       "3  /srv/SystematicClimate/CMIP6/pr_day_IPSL-CM6A-...      1850     2014   \n",
+       "4  /srv/SystematicClimate/CMIP6/pr_day_IPSL-CM6A-...      1850     2014   \n",
+       "\n",
+       "   TCoverage  \n",
+       "0        164  \n",
+       "1        164  \n",
+       "2        164  \n",
+       "3        164  \n",
+       "4        164  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af0b2fea-59a3-4871-9745-3cbce3e29fcf",
+   "metadata": {},
+   "source": [
+    "Y vamos a listar qué modelos tenemos para cada variable. Nos interesan, por el momento, las variables pr y prc, que son la precipitación no convectiva y la convectiva, respectivamente. Precipitación es cualquier flujo de agua desde la atmósfera hacia la superficie, bien en forma líquida o sólida. Precipitación no convectiva es la que resulta de grandes sistemas frontales, la que afecta a grandes zonas, mientras que la convectiva es la típica que surge de tormentas generadas por la evaporación. El modelo las separa porque la no convectiva la resuelve mediante las ecuaciones del modelo, mientras que la no convectiva la tiene que «modelar» con un modelo en que el proceso físico se parametriza. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d0ecf1c6-11e8-4b4a-a735-412d59d29936",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "For var pr we have the following models:\n",
+      "\t   1  - IPSL-CM6A-LR\n",
+      "\t   2  - CAMS-CSM1-0\n",
+      "\t   3  - CanESM5\n",
+      "\t   4  - NorCPM1\n",
+      "\t   5  - KACE-1-0-G\n",
+      "\t   6  - BCC-ESM1\n",
+      "\t   7  - IPSL-CM5A2-INCA\n",
+      "\t   8  - KIOST-ESM\n",
+      "\t   9  - IPSL-CM6A-LR-INCA\n",
+      "For var prc we have the following models:\n",
+      "\t   1  - CanESM5\n",
+      "\t   2  - IPSL-CM6A-LR\n",
+      "\t   3  - CNRM-ESM2-1\n",
+      "\t   4  - CNRM-CM6-1\n",
+      "\t   5  - BCC-ESM1\n"
+     ]
+    }
+   ],
+   "source": [
+    "for g in df.groupby(\"Var\"):\n",
+    "    print(f\"For var {g[0]} we have the following models:\")\n",
+    "    for idx, i in enumerate(g[1][\"Model\"].unique()):\n",
+    "        print(\"\\t{0:4d}  - {1:s}\".format(idx+1, i))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86a461c4-b205-4dde-a204-81d2e1b6e240",
+   "metadata": {},
+   "source": [
+    "# Check data content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c0ac0a72-0427-4978-988e-b1a83a9ad8d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import iris\n",
+    "import iris.plot as iplt\n",
+    "import seaborn as sns\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0c525ad0-ed1a-4414-85fb-b3cae807ea8d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/manuel/miniconda3/envs/sysclim/lib/python3.9/site-packages/iris/fileformats/cf.py:374: UserWarning: Missing CF-netCDF boundary variable 'time_bounds', referenced by netCDF variable 'time'\n",
+      "  warnings.warn(message % (name, nc_var_name))\n",
+      "/home/manuel/miniconda3/envs/sysclim/lib/python3.9/site-packages/iris/fileformats/cf.py:861: UserWarning: Missing CF-netCDF measure variable 'areacella', referenced by netCDF variable 'pr'\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "cubes = iris.load(df.loc[0].File)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "d576b7ab-cafb-4dad-a8e6-552eb69a5708",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: precipitation_flux / (kg m-2 s-1)   (time: 60265; latitude: 10; lon: 5)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cubes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c4677fe9-8fc3-43b1-bb96-874114180cfc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7fe33cde8910>]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAD4CAYAAADLhBA1AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAtaUlEQVR4nO3de7xU5X3v8c9PUJOYWLVijhFTyCnpKSaNUYrklRjTpFYwafFSW40Vj0kPIdFX0zRtDjbHNCYmMZrGhAQhJN7QEGpDCDsBRUQQL9w2F4EtIpv7BoTNbYNsYN9+549ZG4fZc1kzs2bWms33/XrNa2bWep71PDOzZv3WetaznmXujoiISLlOibsCIiLSOyigiIhIJBRQREQkEgooIiISCQUUERGJRN+4K1Bp5557rg8YMCDuaoiI1JRly5btcfd+xeTp9QFlwIAB1NfXx10NEZGaYmZbis2jJi8REYmEAoqIiERCAUVERCKhgCIiIpEIFVDMbLiZrTOzRjMbm2W+mdm4YP4qM7ukUF4zu8HMGsysy8yGpE2/2cxWpj26zOziYN78YFnd884r69OLiEhkCgYUM+sDjAdGAIOBm8xscEayEcCg4DEamBAi7xrgOmBB+oLc/ZfufrG7XwzcAmx295VpSW7unu/uu4v4rCIiUkFhjlCGAo3uvtHd24CpwMiMNCOByZ6yCDjLzM7Pl9fd17r7ugJl3wT8qojPIyIiMQkTUC4AtqW9bwqmhUkTJm8+f0/PgPJI0Nx1l5lZtkxmNtrM6s2svrm5uYjiRCRu7Z1dPFm/ja4u3Vqj1oQJKNk22pm/dK40YfJmL9TsMqDV3dekTb7Z3T8IXB48bsmW190nufsQdx/Sr19RF3qKSMwmLdjI1369imnLm+KuihQpTEBpAi5Me98f2BEyTZi8udxIxtGJu28Png8BU0g1qYlIL7L3zTYAWo60x1wTKVaYgLIUGGRmA83sNFIb+rqMNHXAqKC31zCgxd13hszbg5mdAtxA6pxL97S+ZnZu8PpU4DOkTuyLiEgCFBzLy907zOwOYDbQB3jY3RvMbEwwfyIwC7gaaARagdvy5QUws2uBnwD9gJlmttLdrwqK/TjQ5O4b06pyOjA7CCZ9gGeBn5f16UVEJDKhBod091mkgkb6tIlprx24PWzeYPp0YHqOPPOBYRnTDgOXhqmviIhUn66UFxGRSCigiIhIJBRQREQkEgooIiISCQUUERGJhAKKiIhEQgFFREQioYAiIiKRUEAREZFIKKCIiEgkFFBERCQSCigikijZb5sntUABRUREIqGAIiIikVBAERGRSCigiIhIJBRQREQkEgooIiISCQUUERGJRKiAYmbDzWydmTWa2dgs883MxgXzV5nZJYXymtkNZtZgZl1mNiRt+gAzO2JmK4PHxLR5l5rZ6mBZ48zUY11EJCkKBhQz6wOMB0YAg4GbzGxwRrIRwKDgMRqYECLvGuA6YEGWYje4+8XBY0za9AnB8rvLGh7mQ4qISOWFOUIZCjS6+0Z3bwOmAiMz0owEJnvKIuAsMzs/X153X+vu68JWNFjeme6+0N0dmAxcEza/iIhUVpiAcgGwLe19UzAtTJowebMZaGYrzOx5M7s8rYymMMsys9FmVm9m9c3NzSGKExGRcoUJKNnOU3jINGHyZtoJvNfdPwz8CzDFzM4sZlnuPsndh7j7kH79+hUoTkREotA3RJom4MK09/2BHSHTnBYi7wnc/RhwLHi9zMw2AO8PyuhfzLJERKR6whyhLAUGmdlAMzsNuBGoy0hTB4wKensNA1rcfWfIvCcws37ByXzM7H2kTr5vDJZ3yMyGBb27RgEzwn9UEaklXqgtQxKn4BGKu3eY2R3AbKAP8LC7N5jZmGD+RGAWcDXQCLQCt+XLC2Bm1wI/AfoBM81spbtfBXwc+JaZdQCdwBh33xdU54vAo8DbgaeCh4j0IroWoHaFafLC3WeRChrp0yamvXbg9rB5g+nTgelZpk8DpuVYVj3wgTB1FhGR6tKV8iIiEgkFFBERiYQCioiIREIBRUREIqGAIiIikVBAERGpIe2dXbyy7UDc1chKAUVEpIZ8d9ZaRo5/icbdh+KuSg8KKCIiNWTN9hYA9h1uj7kmPSmgiIhIJBRQREQkEgooIiISCQUUERGJhAKKiCSSF7wXnySNAoqIJIpp/PqapYAiIiKRUEAREakhSb6TpQKKiEgNSmLToAKKiIhEQgFFREQioYAiIiKRCBVQzGy4ma0zs0YzG5tlvpnZuGD+KjO7pFBeM7vBzBrMrMvMhqRNv9LMlpnZ6uD5k2nz5gfLWhk8ziv9o4uI1K4knpzvWyiBmfUBxgNXAk3AUjOrc/dX05KNAAYFj8uACcBlBfKuAa4DfpZR5B7gr919h5l9AJgNXJA2/2Z3ry/+o4qI1L4knozvVjCgAEOBRnffCGBmU4GRQHpAGQlMdncHFpnZWWZ2PjAgV153XxtMO6Ewd1+R9rYBeJuZne7ux0r4fCIiUiVhmrwuALalvW/ixCOGfGnC5M3nemBFRjB5JGjuussyo1HAzEabWb2Z1Tc3NxdRnIiIlCpMQMm20c5svcuVJkze7IWaXQR8H/hC2uSb3f2DwOXB45Zsed19krsPcfch/fr1C1OciEhNSOK5k25hAkoTcGHa+/7AjpBpwuTtwcz6A9OBUe6+oXu6u28Png8BU0g1x4mInHSSeC4lTEBZCgwys4FmdhpwI1CXkaYOGBX09hoGtLj7zpB5T2BmZwEzgTvd/aW06X3N7Nzg9anAZ0id2BcRkQQoGFDcvQO4g1Rvq7XAk+7eYGZjzGxMkGwWsBFoBH4OfClfXgAzu9bMmoCPADPNbHawrDuAPwbuyugefDow28xWASuB7UFZIiKSAGF6eeHus0gFjfRpE9NeO3B72LzB9OmkmrUyp98D3JOjKpeGqa+I1L4knyuQ7HSlvIgkSo7Om1IDFFBERCQSCigiIhIJBRSJXNP+Vr47ay1dXWoEF4lakv9VCigSuTumrGDSgo007DgYd1VEpIoUUCRyHV1dcVdBpNdKcpcFBRQREYmEAoqIiERCAUVERCKhgCIivdprbxzkq0++Qqd6HVacAoqI9GpfemI505Y3sXnv4bir0uspoEgkdh08yuFjHXFXQ0RipIAikbjsu3O57sGX466GSK+X5IY7BRSJzLpdh05474le9UVqWxKvR1FAkchZIld1qTXaHak9CigikijaHaldCigiclJZtmU/T6/ZGXc1eqVQd2wUEektrp+Q6jyy+d5Px1yT3kdHKCIiNSiJ55hCBRQzG25m68ys0czGZplvZjYumL/KzC4plNfMbjCzBjPrMrMhGcu7M0i/zsyuSpt+qZmtDuaNM90rVEROMkne6BUMKGbWBxgPjAAGAzeZ2eCMZCOAQcFjNDAhRN41wHXAgozyBgM3AhcBw4EHg+UQLHd0WlnDi/isIiJSQWGOUIYCje6+0d3bgKnAyIw0I4HJnrIIOMvMzs+X193Xuvu6LOWNBKa6+zF33wQ0AkOD5Z3p7gvd3YHJwDVFf2IRkQrYf7iNy+97jtfeqOyN5ZLY1NUtTEC5ANiW9r4pmBYmTZi8Ycu7IHhdcFlmNtrM6s2svrm5uUBxUoq5a3dxtL0zbxpP8povErHnX29m274jTJi/oSrlJbHpK0xAyVbvzE1FrjRh8oYtL/Sy3H2Suw9x9yH9+vUrUJwUa832Fj7/WD13/64h63yd2RI5OYUJKE3AhWnv+wM7QqYJkzdseU3B62KWJRXQcqQdgC17WytaztH2TtZnDOciIskVJqAsBQaZ2UAzO43UCfO6jDR1wKigt9cwoMXdd4bMm6kOuNHMTjezgaROvi8JlnfIzIYFvbtGATPCflCpPWOnreLKBxZwoLUt7qqISAgFL2x09w4zuwOYDfQBHnb3BjMbE8yfCMwCriZ1Ar0VuC1fXgAzuxb4CdAPmGlmK939qmDZTwKvAh3A7e7e3Vj/ReBR4O3AU8FDeqnFm/YB0NrWyVnviLkyIlJQqCvl3X0WqaCRPm1i2msHbg+bN5g+HZieI893gO9kmV4PfCBMnUVEpLp0pbyIiERCAUUit6qpJe4qSC+gbue1RwFFRJKlQt3Oe0uA8gR/EAUUEendeul1UUm83ksBRSomuftRIrUviQcqCigiIjUkyYOsK6CIJNDoyfW8786ZFVn2kbZO2jq6KrJsObkpoIgk0DOv7qKrQk0af/qNpxnx4wWFE8YlgU05Eo4CSkJsP3Ak0b03pHfZ0Hw47ioUlOCWHclBASUBlm7ex0fvfY5fL2sqnDhBFP9EJJ0CSgK8Hoyou3zrgXgrEpJ2HEUkGwUUEZEakuSmcQUUEZEalMRzTAooUjFJ3pMSkegpoIiISCQUUBJFe/QiUrsUUEROIvPX7Y67CqHVaotprdY7CgooiZLAs2zSqzyxaGvcVSisRv8GSTxJXm0KKCepJ5duY90bh+KuhoiUKIlHQqECipkNN7N1ZtZoZmOzzDczGxfMX2VmlxTKa2bnmNkcM1sfPJ8dTL/ZzFamPbrM7OJg3vxgWd3zziv7GzhJfW3aKq76UYLHc0qTwP+NiGRRMKCYWR9gPDACGAzcZGaDM5KNAAYFj9HAhBB5xwJz3X0QMDd4j7v/0t0vdveLgVuAze6+Mq2sm7vnu3vtNAhX2L7DbRzr6Iy7GpFSC4JIbklsYgtzhDIUaHT3je7eBkwFRmakGQlM9pRFwFlmdn6BvCOBx4LXjwHXZCn7JuBXxXyg2lb6vvgl357DF59YHmFdRESKEyagXABsS3vfFEwLkyZf3ne7+06A4Dlb89Xf0zOgPBI0d91lSb7TTAyee00HbFKIGhClcsIElGwb7cy1MleaMHmzF2p2GdDq7mvSJt/s7h8ELg8et+TIO9rM6s2svrm5OUxxCVFb8dEL/JTadEmyaI2stDABpQm4MO19f2BHyDT58u4KmsUInjN3r28k4+jE3bcHz4eAKaSa1Hpw90nuPsTdh/Tr1y/vh5MS1Fbck5OcVtfqCRNQlgKDzGygmZ1GakNfl5GmDhgV9PYaBrQEzVj58tYBtwavbwVmdC/MzE4BbiB1zqV7Wl8zOzd4fSrwGSD96EXkuINH29l3uC3uaiSQNq9xe3rNGzzT8Ebc1aiIggHF3TuAO4DZwFrgSXdvMLMxZjYmSDYL2Ag0Aj8HvpQvb5DnXuBKM1sPXBm87/ZxoMndN6ZNOx2YbWargJXA9qAsKeBIWyf/Pn01B4+2x12Vqvnze57lkm/PibsakgBJa+ga88QyRj++rOzltHc67Z1dEdQoOn3DJHL3WaSCRvq0iWmvHbg9bN5g+l7gUznyzAeGZUw7DFwapr61qzKr/uOLNjNl8VbedXpf7rz6TytSRtIc60jWH61WvLxhD42732TURwbEXZUK6F1HZzdOWsS7Tu/L6ruvirsqx4UKKFJZVuEVvauIOOXuHG7r5J2na9XonfKvDJ/9+WKAXhpQeof0X/DQsY7Y6pGNhl5JgEK9papp0oKNfOA/ZrPr4NG4qyK9jLvzT79awYvr98RdFakQBZREqcyRSjFj/sxakzpZuOPAkYrURWrLjJXbuX1KdBfM1r2yg394aHFky5NkUUA5CRw/AupdTchSBV+eupKZq3bGUnaSjtwlHAWUk0hk52pC/s+TOBpqrZuxcjt1r2ReBlaM+PYqwq4PlT6nWKpdB48yYOxMnly6rXDiIi3euJe//smLocbjS+a3k6KAchKo1IY9qX/83uzLU1fyT79aUcYSFOVLtaH5TQB+s6Ip8mX/+/TVrN7ewrZ9rZEvu5oUUBKlsn92jXx2ctp+4AhH2+MfiVqhrPdTQEmAau3pK56cnD5673N8IYIL6UQKUUBJgEqffPSgzUtHKCev51+vpUFSa0N7Zxdb9h6OdJm1ft5RASVR4t/iv7LtAAAvhLhWoFq9cDo6u/hmXQPNh45VpTypDE/A1nLGyu2RLevu3zVwxf3zI1kvi7kTR/zfYm4KKFX29emrue2RJVUts5T/8ZrtLblnVjnuzV27m0df3sx/1Gks0Gx+s7yJAWNnajDMEL48dWVky3qpcS8Ah06iMfIK0fgaVfbLxVurXmZ3PKnVXlldQUTsKmF4rqb9rfQ/+x0R1yhZHl+0BYBNew5zzhmnxVyb3JK8Zx2lcj5nrX9HOkJJlOr38mrYkf1IpNZX7G573tReu0SvaX9rpCP9Nu5+M7JlxUkBJQEqfeSQr8nr0+NerGTJFVy2SDwOHungY9+fR9N+DU+USQHlJFJM2ErA+dPjJyq761JKL7XMLM++uot/+a+VZdVLSpOEdSoKrW0njvBbzAn1Qmr9O1JASYCKdxuu8PLnvLqrossvR+Z//R8n1/ObFdH19BGpzTOTlaGT8olS/KrZ2eUFh2s4vtcTbF0374m27/wDc16PdHm51Prem8QtmhUoyiOS3kZHKBXyRstRLvn2nIqfbPvhnHV84gfzQ6Xt/huMHP9SiNSF/3yLNu4LVW6caqln22tvHGTtzoMVLSPOoJzrSLmzy/mLH8yv2KjGUa8BhZZXTnm1PsKyAkqFzFq9k32H23gi6NIZTvEr0+ISNuotRwr3m0/i0UBJ51CqFE8GjJ3J2GmrylrG8B+9wIgfvxBRjWrH4bYONu05XPb3V6zdh46yKYKjdR2wvEUBJQEq3suru5wKFZPA2BOLqRUY1rxclbg6vStEM2v2upSf/tDRdq64f97xER3KMfQ7c/mLkEf3Ek6ogGJmw81snZk1mtnYLPPNzMYF81eZ2SWF8prZOWY2x8zWB89nB9MHmNkRM1sZPCam5bnUzFYHyxpnaszs4eXGPazYuv/Eid1jeRURuIr571e6mUaiE8U/5sH5jVx+3zxmrd7J7kPR3So6zI5P/Zb9bNnbyg+rdN4u3fH/j+WYXoI121sYMHZmJMtKgoIBxcz6AOOBEcBg4CYzG5yRbAQwKHiMBiaEyDsWmOvug4C5wftuG9z94uAxJm36hGD53WUNL+KzVlUxf9xy2k0zy/nsLxZz7YMvl7y8JMr8fl5Y38zPnt8QKq92OaK3eFOqmfVLv1zOx+6dlzft7kNHWffGobxpTuafaMmmE5usT4ZzKEOBRnff6O5twFRgZEaakcBkT1kEnGVm5xfIOxJ4LHj9GHBNvkoEyzvT3Rd66jh+cqE8tadC95QvJU8CTqJ4jiOrWx5awveeei2OKiXG301cWFKzT9Q/a1uBq8U/9v15XPWjBdEWmsfOliNsP1DZCw4z/6XaaXlLmIByAZDeONwUTAuTJl/ed7v7ToDg+by0dAPNbIWZPW9ml6eVkX6rtGz1AMDMRptZvZnVNzdXf9juYd+dy0+fawSSsmFOPVd7xY/qo5dT71KaEOo37+PRlzaVXmgVLNm8j6//dnXBdGF/g10Hj7KxOfoeiW0dxQ9PUs51TR/53nN89N7nSs4fxobm6Lrdx791iFaY61Cy/SMzv4dcacLkzbQTeK+77zWzS4HfmtlFxSzL3ScBkwCGDBlS9d/sjYNvtStvP3CE//nvs5j5Tx/jf/2PMwvkLL6qxWwwi9m0Rnl6avehoxhGv3edHtkywyrlY/ztxIUA/O+PDoy4NpVW+qp+2Xfnhk4b5tYG2RQKbt07X71lXKt0D8x5ne0HjvCDGz6UN10C9j/LEuYIpQm4MO19f2BHyDT58u4KmrG6m7N2A7j7MXffG7xeBmwA3h8sq3+BelRMW0cXHTkO75dv3Z+znfjZtbvp7HKmLsndA6jyvbyKX0vzHlmFXFz3xnzod+by5995tug6vFWXkrPWfHOEu/Pca7vo6ur5JRw/8syY3rj7TT7/6NKCt/294v55vLxhD48v3BxNZWvU7b9cHuk1MC+sb+5xQ7Mfz13Pr5f1vBd9ElowohQmoCwFBpnZQDM7DbgRqMtIUweMCnp7DQNagmasfHnrgFuD17cCMwDMrF9wMh8zex+pk+8bg+UdMrNhQe+uUd15quH9/+8phue4RuC6B1+uajtxqaLauP42wpsUFePg0XZWNR04/n7asiY+9+jSWOpSLb9btZPPPVrPoy9vDp3nGzPWMPe13Szbsj9vui17W/nszxdz14yGMmsZjbg6bc5cvZPbpywvOX9mtfe3tnPrw9W951Gm3QeP8mwMQyIVbPJy9w4zuwOYDfQBHnb3BjMbE8yfCMwCrgYagVbgtnx5g0XfCzxpZp8HtgI3BNM/DnzLzDqATmCMu3d3hfgi8CjwduCp4FE15RyKv77rUKR3izsuxH+wlJ2gfFnW7szfa+ctxW8glm/dz9a9rVzz4Z6nx15q3Mvf/PStq/y/+t+vhKhBbR+i7GpJNZ/uyHKiuXATUpa26Ri/jkJHyr1tb70UYb6CMGn+duJCtu5rZfO9ny6/UkUINZaXu88iFTTSp01Me+3A7WHzBtP3Ap/KMn0aMC3HsuqBD4Spc6W81LiHgeeewXvOenvW+YePdWSd/vKGvby8YW/WeZUfHDKlqNuMxvTfvi7o8pwtoJSi1pu8SrkbYL7PnMRtdm++nKyzy7nv6er3SNxawoWnUdCV8gXc/buGE9pXb/7FYq784fNA6rzKdQ+eOC7W714p57RObfyxwgbAWt9OjJ/XyPLMi0TL0HKknb/72cLjV5mPn9fIN+vyNzeNC3oLliLqHZWrHlhQVg+qJAazdPNe280bLcVfqJkvIC7csJefLdhYTrVqigJKAY+8tLlH++rhttTJzm37W1m+9cAJ88bNXV9GaaX08qqMfDWJYsNw+FgHUxZvrXgzRzHfz6Y9h3kybfiU+2evO37EFIVZq3eyZNM+xs9r5EhbJ/fPXlfUuZFMub65SjXzrdt1qKLXeGR+nh4jPlTYbY8uZeT44m84l+/b7iywfmfOzrcT0NHZxeX3PcfKLNcfbdpzmB8/uz72ZkMNX58AlWznf/SlTcdPzhVzxLDg9dzX74RdZ/MV9+3fv8rUpdt47znv4GODzg1fsSIV85mrNa7Tmh0t/Ok3no5sebl+DvfaOC+R6yfKd66uUp9q18FjFVpy+VqOtLNtX8+A/vjCzcc7Vtx02YWc9663Vbtqx+kIJWJJaw/+5u9eZX3QmSApJ6jnrdtNw47U+F+Zd79LogOtbSWdy8hlzfZoxj7rGSxSv2++VbArxgCTXnLj7kO8mHE9S2tb/m7OUL1G4T1vHuOD35zN6qaWKpVYuqT00gMFlJr1qyVbGTB2JodrYIOc6bZHlrJ6e/g/annnAsrfBF38rTlcek9x19HsbDnC0s3hbi0w5vFljHl8Wd40JQ2fk2Varo4h5bj3qde47ZHiusn+5Q8X8A8PLS677N+u2M6AsTM5GGHAB3hx/R4OHe3gFy8WPv8R5T5kW0cXnV1Oy5H2kkYZyFTtI1Q1eSXML17YyIffezaX/tHZBdNBsg/Ruzx3r7dqierPXuyf+xP3z+dYR9cJ3TZz/befbnijnKoVpSPLBZLlmhhyoM5KbNy6y27ad4TB7zk1suXGNUjjtQ++zJWD382cV3fxiT/px6O3DY2lHqXSEUoZovp/pK+898xcy/UTKjNacCkb164u529++iKzS9jofeHxei76j9nFFxqhlVsPMPgbT7P3zfID75TFW3v06svlWAR7l+Vy77lZrIVzKqX4zfImGnZE3zyV/pfJ9f+Juim5eyyz+euKH4cw7mZtBZSIRXn4O21ZU84RZQudq5m0YEOPQfZKqdrRjk5WNbXwz1NXHp8WdpO05822Ekp8SxTno362YAOtbZ1Zm5+OdXTy+MLNWYc1yebfp6/u0asviZJ2Hq9U+T5G67EOnknbyfnFi5v49Ljie2jlUq24G/WR0NZ9h3msjJ6D5VKTVwLk2qvovhI829WuR4ITmMdyjNf03VnRXkx1pL2TAWNn8o3PDI50LzfMksIWd8eU5fzJu98VuuwfP7ueB+dv4My3n8rIi6O5kDJO05Y3nXAdVLavLc7jk5zdnEPGvxfWN7MiCOj1W/ZT//gy+p5SmYt13xqhu/Dy8yWJMrSHqcvf/2xRRZo1w1JAiVi19my6rwc4eDT8OYpc62NrWwfvOK3nqvD4oi1cf8mJG9qHXtzEmW+Prq06Sr9ftZPfk2uQv54ffn9r6kTuoSK+wySbsngrAFe8vx8AD72wiVNPqa1GiHy96W55qOeJ/zAbz3KO2Cp9rBf19iLOYAJq8opcpW/uUwntHdlXwrt+uybr9Gq3w7/YWNpw6emybVOiaBlqOdIe+pxXOc0bD7246YRbxULu0Ya7P9eLjXsi6UlVDHfPOSp3mNXmg9985vjr7s8xacEGXopgHXi1iFtVd1d12/7WHiMHS246QsnhFy9sLHjr0qgbEDbtie7GPdnkalprbe/g9PZTeNupfSpafj4vrG/m3rS7MKbfea/U+2+kyxc7yvkVZ63eWXBU30rZe7iNT497geZD4TscVHpfYNzcRh549nUa7r6KM04Pt3kpdCK53Obb7gD38Ivhbpo2b93u46+Xbt7PrQ8v4fl/+wRb9mb/fyb5jJV7dYdAUkDJ4Z6Za6tWVvee66KN4a5bKFWuFesj33uO957zDhZ87S/KLqPUu/6Nnbb6hKO7j3wv/JhRX/mvlfTJ0Za+N0/HgOM5itzKbj9whNP7nsK57+x5w7CdLUfo6KzOEdyeN4+xJ0vvtTg3cFOXpprdWo60hw4ouY7couqxtDMYn+uVkBcp3vbIUr5//QdPmHbF/fNzZyijmr2tz50CSo3Ztq+Vy++bF/lyc41OOnnhlhPeF2ru+uR/Ph9ZncKaviL3bQH2Hk4FlGzt6N2T7prRwC0fGRC6vO4BEjff++ke25JiAmGlHClwY63YFLn13LqvterjeXXL0WonBegcSkzCdlXNFOXot2GkN0N1i7LZpFqnYyq1115Mc0K1Pmulj3RL0dHZVdKwL9dGODhnMao1RE1vuyxIASUm6Xc9rNbFSFFcn9Dl8V1FXI6sJ+Wr8L0PGDuTXQeLHxK9t/njrz/FF57IP7xMlK6f8DIXlTEAZzEdT/KtR4X+crnOy2QvJ/kUUGJy8EhpYw/FfdFa1EOpdH+cig9jX4FeXks37ws19E2xAwyu3xX2jpjJle3XXLIpdeRUjVV42Zb9x28zUYpiGhDK+TxT026X0BsooMSk1MAQ916Kc+JheubV+Em1uALNQDdMXMgP57we+XKvfGBB5MushgFjZ7LvcOHREdLXn9+v2pHIZp/1u2s/qMdBAaXGlLM3FEUwylzG/5lcH8FSK3/k9WR9zz3BagXn7o9WSyOiHGhtO+GocfiPwgW57jHMwn7UO6as4LnXdhdOWIZSvvcnFm0tu9yWI+2xD45a7VgdKqCY2XAzW2dmjWY2Nst8M7NxwfxVZnZJobxmdo6ZzTGz9cHz2cH0K81smZmtDp4/mZZnfrCslcHjvPI+fny6V/LbHlnCfz6zriplRrFyHTrWcfz+KiXVIWN3tD3oTlPpJq/9re0891rG2GZV2sK/1axXleIicfG35jBlyVsb1dcKXpN1omI+6v7W8sZ8S6oP3f0MY55YXjhhL1IwoJhZH2A8MAIYDNxkZoMzko0ABgWP0cCEEHnHAnPdfRAwN3gPsAf4a3f/IHAr8HhGWTe7+8XBo7K7NhW0s+UoR9s7mbeu+XjX1jDKOZH80+fKuT1xZeyu4vD7n3s0mqOpYsU9Amypni9htNuTUW3+upUR5ghlKNDo7hvdvQ2YCozMSDMSmOwpi4CzzOz8AnlHAo8Frx8DrgFw9xXu3j3CXQPwNjPreQVZjZswfwN3TFmRc357jo7w5exUd49dlSRx3kFQ8qtU82otNf2Fsb+1jVseWhxqdO1yevzVwvcWJqBcAKQ3QDcF08KkyZf33e6+EyB4ztZ8dT2wwt3Td2MfCZq77rIcbRZmNtrM6s2svrm5MntZP31ufdlNGM+uzX1Ce9DXnzr++guP17MyxzD2tSbzO+vscr765CvsaOnFXWtrYEOQTTnjDObL2tv2If7yhwt4Yf2eUC0A//hY8UfJjbvfZMDYmWU1NVdLmICS7e+Q/WbWPdOEyZu9ULOLgO8DX0ibfHPQFHZ58LglW153n+TuQ9x9SL9+/cIUV7QfPBN9755cZjfs4prx4W7sVGs6upxpy5tiKbtae3w1Gk9qpgdfLUm/9XXmYJ/ZPP96MzOCa9Z+n3ZrgqQKM/RKE3Bh2vv+QOYny5XmtDx5d5nZ+e6+M2geO34+xMz6A9OBUe5+/P6i7r49eD5kZlNINalNDvEZquLr01dXvIxa3Th1y9ybKHXEgChU+9xGL9sxrwmTF26OuwplufXhnkP2FyPV2aV663mYI5SlwCAzG2hmpwE3AnUZaeqAUUFvr2FAS9CMlS9vHamT7gTPMwDM7CxgJnCnux/fLTezvmZ2bvD6VOAzQPbx1askcwPxy8XldzXszRZu2Nuj6a4tpkGTBoydycKNe2MpW6rnGzMaONpenXWs0ucoG0sceLWaCh6huHuHmd0BzAb6AA+7e4OZjQnmTwRmAVcDjUArcFu+vMGi7wWeNLPPA1uBG4LpdwB/DNxlZncF0/4KOAzMDoJJH+BZ4OflfPhydV/521t0Vvho4aafL+ox7TfLcw/sWGlri7g/RjniHt0gacx633mUanipMfk7QKFGG3b3WaSCRvq0iWmvHbg9bN5g+l7gU1mm3wPck6Mql4apb7XsLuI+FFHYd7itouNCxdFm3n0hXG/m7jy+cDNtVRrWPukyg4mCS++h4etryCXfnlPR5de9Uv2jhc6u3h9QZqzcwfQV2znnjNNircdfPVD9WwuE8cyrb8RdBYmIhl4pQy02ZOQbgXXW6ur/sS96zx9Uvcxq675nfdxXhL++K5lt8LXQlCPhKKCU4YlFWwonSphyRmCthD98Z7x77d2+8l8rK7bsU2pw6JVylXrnTqltCihlKGbIFMmuLSHnUPLd9bFcp5yEJ+VLuYBPopfIwSFFKuWpNWo/7400pM7JSQFFpMJOwgMU2tWj7aSkgCJSYSfrBZQ3TIznfvASHwUUkQo7kMBRnqth6eb9cVdBqkwBRUREIqGAIiIikVBAERHppard2U4BRUREIqGAIiIikVBAERGRSCigiIhIJBRQREQkEgooIiK9lFd5eEgFFBERiYQCioiIREIBRUREIhEqoJjZcDNbZ2aNZjY2y3wzs3HB/FVmdkmhvGZ2jpnNMbP1wfPZafPuDNKvM7Or0qZfamarg3njzE7GgcFFRJKpYEAxsz7AeGAEMBi4ycwGZyQbAQwKHqOBCSHyjgXmuvsgYG7wnmD+jcBFwHDgwWA5BMsdnVbW8OI/soiIVEKYI5ShQKO7b3T3NmAqMDIjzUhgsqcsAs4ys/ML5B0JPBa8fgy4Jm36VHc/5u6bgEZgaLC8M919obs7MDktj4iIxCxMQLkA2Jb2vimYFiZNvrzvdvedAMHzeSGW1VSgHgCY2Wgzqzez+ubm5rwfLpczTutTOJGISIKdUuWzAn1DpMlWo8zOzbnShMkbtrzQy3L3ScAkgCFDhpTUEbvhW2pNExEpRpgjlCbgwrT3/YEdIdPky7sraMYieN4dYln9C9RDRERiEiagLAUGmdlAMzuN1Anzuow0dcCooLfXMKAlaMbKl7cOuDV4fSswI236jWZ2upkNJHXyfUmwvENmNizo3TUqLY+IiMSsYJOXu3eY2R3AbKAP8LC7N5jZmGD+RGAWcDWpE+itwG358gaLvhd40sw+D2wFbgjyNJjZk8CrQAdwu7t3Bnm+CDwKvB14KniIiEgCmFf7ll5VNmTIEK+vr4+7GiIiNcXMlrn7kGLy6Ep5ERGJhAKKiIhEQgFFREQioYAiIiKR6PUn5c2sGdgSczXOBfbEXIdMqlM4qlM4qlM4tVSnP3L3fsUsqNcHlCQws/pie0tUmuoUjuoUjuoUTm+vk5q8REQkEgooIiISCQWU6pgUdwWyUJ3CUZ3CUZ3C6dV10jkUERGJhI5QREQkEgooIiISCQWUEpnZw2a228zWpE272MwWmdnK4I6RQ9Pm/ZmZLTSzBjNbbWZvC6ZfGrxvNLNxwdD8Fa+TmZ1qZo8FZa81szvT8lS6Th8KvovVZvY7Mzszbd6dQbnrzOyqqOtUTH3M7EozWxZMX2Zmn4y6PsXWKW3+e83sTTP71yTUKcb1O9dvV631+0IzmxeU0WBmXw6mn2Nmc8xsffB8dlqeSq/jRdUp0vXc3fUo4QF8HLgEWJM27RlgRPD6amB+8LovsAr4UPD+D4E+weslwEdI3ZHyqe78VajTZ4Gpwet3AJuBAVWq01LgiuD154BvB68HA68ApwMDgQ1Rf09F1ufDwHuC1x8AtqflieU7Sps/Dfhv4F/jrlPM63euOlVr/T4fuCR4/S7g9WA9vg8YG0wfC3y/iut4sXWKbD3XEUqJ3H0BsC9zMtC91/YHvHVHyb8CVrn7K0Heve7eaak7VZ7p7gs99etNBq6pUp0cOMPM+pK6v0wbcLBKdfoTYEHweg5wffB6JKmNwDF330Tq/jpDo6xTMfVx9xXu3v19NQBvs9SN3+L8jjCza4CNQZ26p8VZpzjX71x1qtb6vdPdlwevDwFrgQtIrcuPBckeSyujGut4UXWKcj1XQInWPwP3m9k24AdA92H2+wE3s9lmttzMvhZMv4DUrY27NQXTqlGnXwOHgZ2kbnD2A3ffV6U6rQH+Jnh9A2/d8vkCYFuWsitdp1z1SXc9sMLdj1WhPjnrZGZnAP8XuDsjfZy/W5zrd646VX39NrMBpPb2FwPv9tRdZgmezwuSVXUdD1mndGWt5woo0foi8BV3vxD4CvBQML0v8DHg5uD5WjP7FKnDyExR9+POVaehQCfwHlKH3l81s/dVqU6fA243s2WkDsnbgum5yq50nXLVJ1Ups4uA7wNfKFDPKOWq093AA+7+Zkb6OOsU5/qdq05VXb/N7J2kmiH/2d0P5kuao/zI61VEnbrTl72eF7wFsBTlVuDLwev/Bn4RvG4Cnnf3PQBmNotUW/ATQP+0/P15q0mq0nX6LPC0u7cDu83sJWAI8EKl6+Tur5FqJsHM3g98OpjVxIlHB91lN1WyTnnqg5n1B6YDo9x9Q1o94/qOLgP+1szuA84CuszsKKkNR5y/Wyzrd546VW39NrNTSX3/v3T33wSTd5nZ+e6+M2g62h1Mr8o6XmSdIlvPdYQSrR3AFcHrTwLrg9ezgT8zs3cEbbpXAK8Gh52HzGxY0HtiFDCjSnXaCnzSUs4AhgGvVaNOZnZe8HwK8P+AicGsOuDGoP12IDAIWFLpOuWqj5mdBcwE7nT3l7rTx/kdufvl7j7A3QcAPwK+6+4/jfl3i239zlOnqqzfwTIeAta6+w/TZtWR2pkjeJ6RNr2i63ixdYp0PS+m94AeJ/Sk+BWp9tl2UpH886QO95eR6sWxGLg0Lf0/kDrhtQa4L236kGDaBuCnBKMXVLpOwDtJHbE0AK8C/1bFOn2ZVM+T14F705cPfD0odx1pPUqiqlMx9SG1gToMrEx7nBf3d5SW75uc2Msrzt8trvU7129XrfX7Y6SagValrSNXk+rpNpfUDtxc4JwqruNF1SnK9VxDr4iISCTU5CUiIpFQQBERkUgooIiISCQUUEREJBIKKCIiEgkFFBERiYQCioiIROL/A3zv6Ta5P0g/AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "iplt.plot(cubes[0][:,0,0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6ed98fc0-f733-44bc-ba6b-b06fc30c0e03",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_30116/3819972166.py:1: RuntimeWarning: divide by zero encountered in log\n",
+      "  sns.histplot(np.log(cubes[0][:,0,0].data))\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:ylabel='Count'>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAD4CAYAAAAdIcpQAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAW8UlEQVR4nO3df5Bd5X3f8fc32mW1SGURZaEYMZUylT0Gd6ZJZOrYdaYJnkJSj4UzxpbHVpSCi3GxcZzmB5gZOzMedYgbqBMXK1FtGpE4porjBBGHxBhhe5gmKLKNf4gfgxqiH4aAEktXWCBZK779454rDqu7Oitp7z3n7n2/Znbuuc85d++Xy+5+dJ7nOc+JzESSpBP5kboLkCQ1n2EhSapkWEiSKhkWkqRKhoUkqdJI3QX0yrnnnpvLli2ruwxJGihf//rX/zEzJ6e3z9uwWLZsGdu2bau7DEkaKBGxs1u73VCSpEqGhSSpkmEhSapkWEiSKhkWkqRKhoUkqZJhIUmqZFhIkioZFpLUA5nJ/v37mS/3DDIsJKkHWq0Wq2+7h1arVXcpc6JnYRERd0TEsxHx3VLbORFxX0Q8UTwuKe27KSJ2RMTjEXF5qf0nIuI7xb7fiYjoVc2SNJdGFy6qu4Q508szi98HrpjWdiNwf2auAO4vnhMRFwOrgUuK13wqIhYUr1kPXAusKL6mf09JUo/1LCwy82vA96c1rwI2FtsbgStL7Xdl5uHMfBLYAVwaERcAZ2XmX2e74+/O0mskSX3S7zGL8zPzaYDi8byi/UJgd+m4PUXbhcX29PauIuLaiNgWEdv27t07p4VL0jBrygB3t3GIPEF7V5m5ITNXZubKycnjlmOXJJ2ifofFM0XXEsXjs0X7HuCi0nFLgaeK9qVd2iVJfdTvsNgMrC221wJ3l9pXR8RYRCynPZC9teiqei4iXlfMgvqF0mskSX3SszvlRcTngH8PnBsRe4CPArcAmyLiGmAXcBVAZm6PiE3AI8AUcH1mHi2+1ftoz6waB+4tviRJfdSzsMjMd86w67IZjl8HrOvSvg14zRyWJkk6SU0Z4JYkNZhhIUmq1LNuKEkaRplJq9WaNwsIdnhmIUlzqLOA4IEDB+ouZU55ZiFJc6BzRtFqtRgZO3PerDbbYVhI0hxotVqsWb+FIy8cZGpqihs2PsjCiX9+7J4WEcHExASDunC2YSFJc2R0fDEJTD3XYmRsnKlDz/OLn/wLxs+eZGRkAX/wvp/h7LPPrrvMU2JYSFIPjYyNMzq+iJGRwf5z6wC3JKmSYSFJqmRYSJIqGRaSpEqGhSSpkmEhSapkWEiSKhkWkqRKhoUkqZJhIUmqZFhIkioZFpJ0mjrLk89nhoUknaZWq8XVt9/L1NRU3aX0jGEhSXNgdGxR3SX0lGEhSapkWEiSKhkWkqRKhoUknYZhmAkFhoUknZZjM6GOzt+ZUGBYSNJpm+8zocCwkCTNgmEhSapkWEiSKtUSFhHxoYjYHhHfjYjPRcTCiDgnIu6LiCeKxyWl42+KiB0R8XhEXF5HzZJ0OjqzpjKz7lJOSd/DIiIuBG4AVmbma4AFwGrgRuD+zFwB3F88JyIuLvZfAlwBfCoiFvS7bkk6HUcOHeQ9Gx4Y2Gm2dXVDjQDjETECnAk8BawCNhb7NwJXFturgLsy83BmPgnsAC7tb7mSdPpGFp5ZdwmnrO9hkZnfA34L2AU8DbQy80vA+Zn5dHHM08B5xUsuBHaXvsWeok2S1Cd1dEMtoX22sBx4BbAoIt59opd0aeva6RcR10bEtojYtnfv3tMvVpIE1NMN9Sbgyczcm5lHgC8ArweeiYgLAIrHZ4vj9wAXlV6/lHa31XEyc0NmrszMlZOTkz37D5CkYVNHWOwCXhcRZ0ZEAJcBjwKbgbXFMWuBu4vtzcDqiBiLiOXACmBrn2uWpKE20u83zMyHIuLzwDeAKeCbwAZgMbApIq6hHShXFcdvj4hNwCPF8ddn5tF+1y1Jw6zvYQGQmR8FPjqt+TDts4xux68D1vW6LklSd7WEhSTpeOXlzicmJmj31DeDy31IUkO0Wi3WrN/CmvVbGnfxnmcWktQgo+OL6y6hK88sJEmVDAtJapgmLjpoWEhSA5QHt5u46KBhIUkNcOxe3lPte3k3bdFBw0KSatY5q2jyvbwNC0mq2bGziqNTdZcyI8NCkhqgyWcVYFhIkmbBsJCkPmnilNjZMiwk6RRkJvv37z+pP/xTh55v3JTY2TIsJOkUtFot3nHrZnbv3l19cEnTpsTOlmEhSacoCG7Y+GCjZzHNFRcSlKST0Bl36HQljYyN11xRfxgWknQSOsuIH3nh4FCcUXTYDSVJJ2l0fDEj482+LmKuGRaSpEqGhSSpkmEhSapkWEiSKhkWkqRKhoUkqZJhIUl9NKiLCRoWktRH0xcTLN97u6xpoWJYSFKflRcTnOkueU1bodawkKSazXSXvCatUGtYSJIqGRaSpEqGhSTVZKbB7SYyLCSpJjMNbjdRLWEREWdHxOcj4rGIeDQifjIizomI+yLiieJxSen4myJiR0Q8HhGX11GzJM2V8g2UZhrcbpq6bn7028BfZubbIuIM4Ezgw8D9mXlLRNwI3Aj8ekRcDKwGLgFeAXw5Il6ZmUdrql3SkJqrbqOpQ89z3Z1bySOHBuKsAmo4s4iIs4CfAj4DkJk/zMz9wCpgY3HYRuDKYnsVcFdmHs7MJ4EdwKX9rFmSoNRtNHX6f+BHxxcN1A2U6uiG+lFgL/C/I+KbEfHpiFgEnJ+ZTwMUj+cVx18I7C69fk/RdpyIuDYitkXEtr179/buv0DS0BqUbqO5NquwiIg3zKZtlkaAHwfWZ+aPAQdpdznN+PZd2rpe/56ZGzJzZWaunJycPMXyJEnTzfbM4pOzbJuNPcCezHyoeP552uHxTERcAFA8Pls6/qLS65cCT53ie0uSTsEJB7gj4ieB1wOTEfHLpV1nAQtO5Q0z8x8iYndEvCozHwcuAx4pvtYCtxSPdxcv2Qz8UUTcRnuAewWw9VTeW5J0aqpmQ50BLC6O+2el9gPA207jfT8AfLaYCfV3wH+ifZazKSKuAXYBVwFk5vaI2EQ7TKaA650JJUn9dcKwyMyvAl+NiN/PzJ1z9aaZ+TCwssuuy2Y4fh2wbq7eX5IGQWeq7sTEBBHdhm/7Z7ZjFmMRsSEivhQRWzpfPa1MkoZck5Ypn+1FeX8M/C7wacAuIEnqk6YsUz7bsJjKzPU9rUSS1Fiz7Ya6JyL+S0RcUKzhdE5EnNPTyiRJjTHbM4u1xeOvltqS9tXYkqR5blZhkZnLe12IJKm5ZhUWEfEL3doz8865LUeS1ESz7YZ6bWl7Ie3rIb4BGBaSNARm2w31gfLziJgA/qAnFUmSGudUlyh/nvYaTZKkITDbMYt7eGlZ8AXAq4FNvSpKktQssx2z+K3S9hSwMzP39KAeSVIDzaobqlhQ8DHaK88uAX7Yy6IkSc0y2zvlvZ32PSSuAt4OPBQRp7NEuSRpgMy2G+pm4LWZ+SxAREwCX6Z9lztJ0jw329lQP9IJisI/ncRrJWngde4tMaxme2bxlxHxV8DniufvAP6iNyVJUvO0Wi2uvv1eYmSMM+oupgZV9+D+V8D5mfmrEfHzwL8DAvhr4LN9qE+SGmN0bBFTR6fqLqMWVV1JnwCeA8jML2TmL2fmh2ifVXyit6VJkpqiKiyWZea3pzdm5jZgWU8qkiQ1TlVYLDzBvvG5LESS1FxVYfG3EfGfpzdGxDXA13tTkiSpaapmQ/0S8KcR8S5eCoeVwBnAW3tYlySpQU4YFpn5DPD6iPhp4DVF8xczc0vPK5MkNcZs72fxAPBAj2uRJDWUV2FLkioZFpKkSoaFJFUY9nWhwLCQpEqddaGGdakPMCwkaVZGxxbVXUKtDAtJUqXZLlEuSapBebxkYmKCiKiljtrOLCJiQUR8MyL+vHh+TkTcFxFPFI9LSsfeFBE7IuLxiLi8rpolqd+mDj3PdXduZc36LbUOstfZDfVB4NHS8xuB+zNzBXB/8ZyIuBhYDVwCXAF8KiIW9LlWSarN6PgiRscX11pDLWEREUuB/wh8utS8CthYbG8Eriy135WZhzPzSWAHcGmfSpUkUd+ZxSeAXwNeLLWdn5lPAxSP5xXtFwK7S8ftKdqOExHXRsS2iNi2d+/eOS9akoZV38MiIt4MPJuZs13ivNtoTnY7MDM3ZObKzFw5OTl5yjVKkl6ujtlQbwDeEhE/R/vmSmdFxB8Cz0TEBZn5dERcADxbHL8HuKj0+qXAU32tWJKGXN/PLDLzpsxcmpnLaA9cb8nMdwObgbXFYWuBu4vtzcDqiBiLiOXACmBrn8uWpKHWpOssbgE2FXfh2wVcBZCZ2yNiE/AIMAVcn5lH6ytTkoZPrWGRmV8BvlJs/xNw2QzHrQPW9a0wSdLLuNyHJKmSYSFJqmRYSJIqNWmAW5IapbOI37Df+AgMC0maUavVYs36LRx54eBQ3/gI7IaSpBMaHV/MyPhw3/gIDAtJ0iwYFpKkSoaFJKmSYSFJXZRvZyrDQpK6arVaXH37vUxNDfcsqA7DQpJmMDrmLKgOw0KSBkCnWyyz673fes6wkKQBcOTQQd6z4YHaxlEMC0kaECMLz6ztvQ0LSVIlw0KSVMmwkKRpvMbieIaFJE1z7BqLIV9ptsywkKQuvMbi5QwLSVIlw0KSVMmwkCRVMiwkSZUMC0kqcdpsd4aFJJU4bbY7w0KSpnHa7PEMC0lSJcNCklTJsJAkVTIsJEmV+h4WEXFRRDwQEY9GxPaI+GDRfk5E3BcRTxSPS0qvuSkidkTE4xFxeb9rlqRhV8eZxRTwXzPz1cDrgOsj4mLgRuD+zFwB3F88p9i3GrgEuAL4VEQsqKFuSapVnffh7ntYZObTmfmNYvs54FHgQmAVsLE4bCNwZbG9CrgrMw9n5pPADuDSvhYtaSg0/YK8qUPP13Yf7lrHLCJiGfBjwEPA+Zn5NLQDBTivOOxCYHfpZXuKtm7f79qI2BYR2/bu3duzuiXNT4NwQV5d9+GuLSwiYjHwJ8AvZeaBEx3apa3rOVhmbsjMlZm5cnJyci7KlDRkvCCvu1rCIiJGaQfFZzPzC0XzMxFxQbH/AuDZon0PcFHp5UuBp/pVqySpntlQAXwGeDQzbyvt2gysLbbXAneX2ldHxFhELAdWAFv7Va8kCUZqeM83AGuA70TEw0Xbh4FbgE0RcQ2wC7gKIDO3R8Qm4BHaM6muz8yjfa9akoZY38MiMx+k+zgEwGUzvGYdsK5nRUkaWp0ZUBMTE3WX0mhewS1pqLVaLd5x62Z27drV6GmzdaujG0qSGiUIrrtzK3nkUKOnzdbJMwtJAkbHFzEy7rTZmRgWkoZW06/YbhLDQtLQGoQrtpvCsJA01Abtiu26FhM0LCQNpUHtgqprMUHDQtJQGuQuqDoWEzQsJA2tQeuCqpNhIUmq5EV5koZKZ6xiEMcr6mRYSBoqrVaLNeu3cOSFgwM5XlEXu6EkDZ3R8cVerX2SDAtJUiXDQpJUyTELSUOhriuf5wvPLCQNhVarxerb7uHAgQN1lzKQDAtJQ2Nk7EynzJ4iw0LSvJSZ7N+/n/379/Piiy/SarWYOvQ8N2x8kKkpp8yeLMcsJM1LnespMpP/9uYVfOgP/y8xMsbI2HjdpQ0kzywkzVuj44shghs2PkiMjNVdzkAzLCTNe/PtbKKOmV2GhaR5Z1DvVTFbddzTwrCQNG+UB7Wvvv3eeT2Q3e97WhgWkuaNVqvFO27dzO7du71XxRwzLCTNC52up6A9oO2KsnPLqbOSBlr5/hRX336v02N7xLDQSev8ck5MTBARdZejIVe+P4XTY3vHbih11RkozMyXDRp2gmL1bffM69kmGgydn0fvT9F7hoW6KgdC519ua9ZvORYQowsXHRciUr91up7m86ynmXSCsl+/f4aFZjS68KV/qY2OL25fDVty4MCB40JE6pVuZ7uZObSznqYOPc91d27t2++fYaFjyr+As9UtRKS5lpns2rXrZWe7nSmyw2x0fFHffv8GJiwi4oqIeDwidkTEjXXXM1+UA+J0xyJOJWykKp2guPr2e2HkjGNh4RTZtn4t/TEQYRERC4DbgZ8FLgbeGREX11tVdyf7B3O2x59owHn6MVXtJwqIctdTtxq6/VB2vt/OnTsd+NaMOj8n+/bt4/vf//6xr3379h37uSzv27dvH/v27WPnzp3HpsR2ul7e+5mvMXV0yimywJFDB7nm97awc+fOY59lLwzK1NlLgR2Z+XcAEXEXsAp4pBdvtn///lN+bWfA7Y7rf5aJiYk5O758HMB7P/M1AH7vmp869rpWqzWrduBl36tzDLR/8Lpuv/ADjrxwkLW/vYPf+cU3HtvXaX/3x78NwPiSScNCXXV+Do8cOsjhHzx3rH1k4Zls/OCbAVhz65/w4tRRoP2z9OKRQxz+wXPtmU5HXwA41u0ydfiFY9/jyAsHySOHXtZ2su29OrZf7/fuj/8xIwvP5M8+8i7OPvts5loMQpdBRLwNuCIz31M8XwP828x8/7TjrgWuLZ6+Cni8r4W2nQv8Yw3vezoGsWYYzLoHsWYYzLoHsWaov+5/mZmT0xsH5cyi25Vfx6VcZm4ANvS+nJlFxLbMXFlnDSdrEGuGwax7EGuGwax7EGuG5tY9EGMWwB7gotLzpcBTNdUiSUNnUMLib4EVEbE8Is4AVgOba65JkobGQHRDZeZURLwf+CtgAXBHZm6vuayZ1NoNdooGsWYYzLoHsWYYzLoHsWZoaN0DMcAtSarXoHRDSZJqZFhIkioZFnMkIv5PRDxcfP19RDxc2ndTsUzJ4xFxeY1lHiciPlDUtT0iPl5qb2TNEfEbEfG90mf9c6V9jay5LCJ+JSIyIs4ttTWy7oj4WER8u/icvxQRryjta2TNABHx3yPisaL2P42Is0v7Gll3RFxV/A6+GBErp+1rRs2dy+z9mrsv4FbgI8X2xcC3gDFgOfD/gAV111jU9tPAl4Gx4vl5A1DzbwC/0qW9sTWXaryI9iSNncC5Ta8bOKu0fQPwu02vuajvPwAjxfZvAr/Z9LqBV9O+kPgrwMpSe2Nq9sxijkX71nFvBz5XNK0C7srMw5n5JLCD9vIlTfA+4JbMPAyQmc8W7U2ueSaDUPP/AH6Nl19Q2ti6M/NA6ekiXqq7sTUDZOaXMrOzuuDf0L4uCxpcd2Y+mpndVpxoTM2Gxdx7I/BMZj5RPL8QKK+jvKdoa4JXAm+MiIci4qsR8dqivck1A7y/6GK4IyKWFG2Nrjki3gJ8LzO/NW1X0+teFxG7gXcBHymaG13zNFcD9xbbg1R3R2NqHojrLJoiIr4M/Isuu27OzLuL7Xfy0lkFzHKpkl45Uc20//8vAV4HvBbYFBE/SrNrXg98rKjnY7S7/K6m5pqhsu4P0+4eOe5lXdoa8Vln5t2ZeTNwc0TcBLwf+CgN/6w7v4sRcTMwBXy287Iuxzfms57pZV3aarnewbA4CZn5phPtj4gR4OeBnyg117pUyYlqjoj3AV/Idufo1oh4kfYiZo2tuSwi/hfw58XT2peEmanuiPjXtPubv9XupWQp8I2IuJQB+ayBPwK+SDssGvtZd0TEWuDNwGXFzzcMzmddVvtn3WE31Nx6E/BYZu4ptW0GVkfEWEQsB1YAW2up7nh/BvwMQES8EjiD9mqXja05Ii4oPX0r8N1iu7E1Z+Z3MvO8zFyWmcto/wH48cz8Bxpcd0SsKD19C/BYsd3YmqF9ozTg14G3ZObzpV2NrnsGjanZM4u5tZqXd0GRmdsjYhPte29MAddn5tE6iuviDuCOiPgu8ENgbfGvsCbX/PGI+De0T8X/HngvNP5znlHD674lIl4FvEh7Btd10PiaAf4n7dlD9xVncn+Tmdc1ue6IeCvwSWAS+GJEPJyZlzepZpf7kCRVshtKklTJsJAkVTIsJEmVDAtJUiXDQpJUybCQJFUyLCRJlf4/farLyMKYkdQAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.histplot(np.log(cubes[0][:,0,0].data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 136,
+   "id": "7ff5d4bf-a490-45c4-8485-005598e383b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(60265, 1, 1)"
+      ]
+     },
+     "execution_count": 136,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e84a9314-ca52-4e14-9591-68597ab936ec",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:sysclim]",
+   "language": "python",
+   "name": "conda-env-sysclim-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/DownloadCMIP6.ipynb
+++ b/notebooks/DownloadCMIP6.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "686e2699-9265-44d6-ae2a-561f375c5940",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyesgf.search import SearchConnection\n",
+    "import xarray as xr\n",
+    "import os.path as op\n",
+    "from tqdm import tqdm\n",
+    "from datetime import datetime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7c119f7-02d9-4c22-a4e9-cc7ae2c76fa4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = SearchConnection('http://esgf-data.dkrz.de/esg-search',\n",
+    "                        distrib=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b4a8d9e-452b-4078-91f3-2eacc57b2097",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctx = conn.new_context(project='CMIP6',\n",
+    "                       variable='prc',\n",
+    "                       experiment_id=\"historical\",\n",
+    "                       frequency=\"day\")\n",
+    "ctx.hit_count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "278a0af7-27e3-4b9d-a6cf-bf66826bf54f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctx.get_facet_options().keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97183d37-94cc-4b87-a820-4f4a0b22b1c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datos = ctx.search()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fe93da8-dfd9-4414-9f1c-26b8fee77e23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for idx, i in tqdm(enumerate(datos), total=len(datos)):\n",
+    "    fc = i.file_context().search()[0]\n",
+    "    outfile = op.join(\"./CMIP6\", op.basename(fc.opendap_url))\n",
+    "    if op.isfile(outfile):\n",
+    "        continue\n",
+    "    with xr.open_dataset(fc.opendap_url) as ds:\n",
+    "        prc = ds[\"prc\"]\n",
+    "        prc = prc.sel(lat=slice(43, 44), lon=slice(355, 357))\n",
+    "        prc.to_netcdf(outfile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a06946c8-eb58-4dfc-8989-f3698a55ecbf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctx = conn.new_context(project='CMIP6',\n",
+    "                       variable='prc',\n",
+    "                       experiment_id=\"historical\",\n",
+    "                       frequency=\"day\",\n",
+    "                       from_timestamp = datetime(1980,1,1).isoformat()+\"Z\",\n",
+    "                       to_timestamp = datetime(2010,12,31, 23, 59, 59).isoformat()+\"Z\")\n",
+    "ctx.hit_count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c574b31-63b1-43d0-b356-3b35b8742015",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datos = ctx.search()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "754b8aa4-5141-4e1c-af93-e23d280f59a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for idx, i in tqdm(enumerate(datos), total=len(datos)):\n",
+    "    fc = i.file_context().search()[0]\n",
+    "    print(fc.opendap_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20e721bf-6bef-4f97-8577-caad668eb1f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datetime(2010,12,31, 23, 59, 59).isoformat()+\"Z\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67485260-67c4-451c-a8a8-7579ad890099",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:sysclim]",
+   "language": "python",
+   "name": "conda-env-sysclim-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
He creado un código para descargar los datos, que se encuentra en la carpeta code. Este código se conecta a los servidores de descarga y baja todo lo que responda a la cadena de búsqueda. Los servidores funcionan un poco de aquella manera, así que el código lo reejecuto de tanto en tanto para descargar ficheros que en ocasiones anteriores pudieran haber quedado colgados.

También hay un Jupyter Notebook para chequear las descargas. Todo muy básico, pero para que por lo menos puedas ver por dónde van los tiros. Para explorar de forma más interactiva los ficheros NetCDF (.nc) te recomiendo instalar el programa [Panoply](https://www.giss.nasa.gov/tools/panoply/).

A partir de aquí, hablamos y vemos cómo tendría que preparar los datos para poder empezar a hacer pruebas.